### PR TITLE
chore: add crisp as a linter to the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+  - repo: https://github.com/Weburz/crisp
+    rev: v0.1.4
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
+      - id: crisp
+        name: lint git-commit messages


### PR DESCRIPTION
This PR will configure `crisp` for linting the commits during the dev work on the project, the config is in the `pre-commit-config.yaml` file. 