### PR TITLE
chore: add crisp to the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,9 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
+  - repo: https://github.com/Weburz/crisp
+    rev: v0.1.4
+    hooks:
+      - id: crisp
+        name: lint git-commit messages


### PR DESCRIPTION
This PR will add the crisp commit linter to the project. 

You can find it in [this repository](https://github.com/Weburz/crisp).